### PR TITLE
Fix Scroll for yearList

### DIFF
--- a/paper-date-picker.css
+++ b/paper-date-picker.css
@@ -94,7 +94,7 @@ paper-calendar {
 #yearList {
   @apply(--layout-vertical);
   display: block;
-  height: 100%;
+  height: 240px;
   overflow-y: auto;
   overflow-x: hidden;
 }


### PR DESCRIPTION
When change year is selected the height of the div container is 100% and the scroll does not work. I change it for the fix height (240px) as paper-calendar
